### PR TITLE
updated bazel test step to remove broken benchmark tests

### DIFF
--- a/pipelines/post-merge.yaml
+++ b/pipelines/post-merge.yaml
@@ -28,5 +28,5 @@ stages:
       displayName: 'show bazel version'
     - script: |
         cd bazel-hello
-        bazel test ... 
-      displayName: 'run all tests'
+        bazel test --test_tag_filters=-benchmark ... 
+      displayName: 'run all non-benchmark tests'


### PR DESCRIPTION
post-merge.yaml updated:
* added filter to bazel test step, the filter ignores any "benchmark" tests