### PR TITLE
re-introduced remote cache to pre-merge pipeline; changed trigger in …

### DIFF
--- a/pipelines/post-merge.yaml
+++ b/pipelines/post-merge.yaml
@@ -1,17 +1,15 @@
 # Pipeline to run Bazel tests post-merge onto master
-
-# disable CI builds 
-trigger: none
-
-# pre-merge pipeline specified as a resource to act as the trigger for builds of this pipeline
-resources: 
-  pipelines:
-  - pipeline: pre-merge-pipeline
-    source: pre-merge-pipeline
-    trigger:
-      branches:
-        include: 
-        - master
+ 
+# allow CI builds only on master branch by excluding all other branches.
+# enforce batch run, which will test all changes at once. This should result in a single run per PR that is merged onto master.
+# the single run will include all changes introduced by the PR, instead of testing them sequentially.
+trigger: 
+  batch: true 
+  branches:
+    include:
+    - master 
+    exclude:
+      - '*'
 
 stages:
 - stage: Bazel_Tests

--- a/pipelines/pre-merge.yaml
+++ b/pipelines/pre-merge.yaml
@@ -31,5 +31,5 @@ stages:
 
     - script: |
         cd bazel-hello
-        bazel build ...
+        bazel build --remote_cache=http://remotecache.eastus.cloudapp.azure.com:9090 ...
       displayName: 'bazel build' 


### PR DESCRIPTION
…post-merge pipeline to run once following a PR onto master branch, the single run will include all changes introduced by PR without running a build sequentially for each individual commit