### PR TITLE
explicitly disabled PR trigger in post-merge.yaml

### DIFF
--- a/pipelines/post-merge.yaml
+++ b/pipelines/post-merge.yaml
@@ -11,6 +11,8 @@ trigger:
     exclude:
       - '*'
 
+pr: none
+
 stages:
 - stage: Bazel_Tests
   displayName: Test


### PR DESCRIPTION
Explicitly set pr triggers to none to prevent pipeline from running on an open PR