### PR TITLE
Migrate agent; add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# members of @muon-developers/muon  will be requested for
+# review when someone opens a pull request.
+*       @muon-developers/muon 
+
+# In this example, @doctocat owns any files in the /folder/subfolder/
+# directory at the root of the repository and any of its
+# subdirectories.
+
+# /folder/subfolder/ @doctocat

--- a/pipelines/post-merge.yaml
+++ b/pipelines/post-merge.yaml
@@ -17,7 +17,7 @@ stages:
   jobs:
   - job: Test
     pool:
-      vmImage: 'ubuntu-latest'
+      name: 'VMSSPool'
     steps:  
     - script: |
         echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list

--- a/pipelines/post-merge.yaml
+++ b/pipelines/post-merge.yaml
@@ -20,11 +20,6 @@ stages:
       name: 'VMSSPool'
     steps:  
     - script: |
-        echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-        curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-        sudo apt-get update && sudo apt-get install -y bazel
-      displayName: 'install bazel'
-    - script: |
         bazel version
       displayName: 'show bazel version'
     - script: |

--- a/pipelines/pre-merge.yaml
+++ b/pipelines/pre-merge.yaml
@@ -16,19 +16,8 @@ stages:
 
     steps: 
     - script: |
-        echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-        curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-        sudo apt-get update && sudo apt-get install -y bazel
-      displayName: 'install bazel'
-
-    - script: |
         bazel version
       displayName: 'show bazel version'
-
-    - script: |
-        cd bazel-hello
-        bazel clean 
-      displayName: 'clean project' 
 
     - script: |
         cd bazel-hello

--- a/pipelines/pre-merge.yaml
+++ b/pipelines/pre-merge.yaml
@@ -12,7 +12,7 @@ stages:
   jobs:
   - job: Build
     pool:
-      vmImage: 'ubuntu-latest'
+      name: 'VMSSPool'
 
     steps: 
     - script: |


### PR DESCRIPTION
- Migrates pre-merge.yaml & post-merge.yaml to use the new VMSSPool as its agent of choice.
- Added code owners file and @muon-developers/muon as code owners 