### PR TITLE
Added Mergify config

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -1,0 +1,19 @@
+# Simple merge rule 
+pull_request_rules: 
+  - name: automatic merge when CI passes and 1+ approved reviews
+    conditions: 
+    - "#approved-reviews-by>=1"
+    - status-success=pre-merge
+    - base=master 
+    actions: 
+      merge: 
+        method: merge 
+
+# Alternative merge rule 
+# pull_request_rules: 
+#   - name: automatic merge when GitHub branch protection passes 
+#     conditions:
+#     - base=master
+#     actions:
+#       merge: 
+#         method: merge 


### PR DESCRIPTION
Added a simple mergify config file that once merged into master should allow automatic PR merging once 1 approval has been reached and the CI check has passed. 
There is also an alternative (commented out) set of rules that when enabled will allow github branch protection rules to dictate when the PR can be merged automatically. (essentially the same rule set as the first example, but offers an alternative way of managing auto merge) 